### PR TITLE
Adding the ability to automatically create letter folders

### DIFF
--- a/folders_exmaple.yml
+++ b/folders_exmaple.yml
@@ -12,7 +12,8 @@ system_folders:
               - Other
         - Other:
               - Images:
-                  - "A-Z" # Use this notation to create a folder for each letter of the alphabet (and a numerical 0-9 folder)
+                  - "<alphabetical>" # Use this notation to create a folder for each letter of the alphabet
+                  - "<numerical>" # Use this notation to create a folder for each number 0-9
               - Videos
               - Other
     documents:

--- a/folders_exmaple.yml
+++ b/folders_exmaple.yml
@@ -11,7 +11,8 @@ system_folders:
               - Videos
               - Other
         - Other:
-              - Images
+              - Images:
+                  - "A-Z" # Use this notation to create a folder for each letter of the alphabet (and a numerical 0-9 folder)
               - Videos
               - Other
     documents:

--- a/src/Command/FolderCreatorCommand.php
+++ b/src/Command/FolderCreatorCommand.php
@@ -51,7 +51,12 @@ class FolderCreatorCommand extends AbstractCommand
     {
         foreach ($folders as $folder) {
             if (is_string($folder)) {
-                $this->$createFolderFunction($parent, $folder);
+                if ($folder == '[A-Z]') {
+                    $folder = ['(0-9)', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z'];
+                    $this->loopThroughFolders($folder, $parent, $createFolderFunction);
+                } else {
+                    $this->$createFolderFunction($parent, $folder);
+                }
             } else if (is_array($folder)) {
                 foreach ($folder as $folderName => $innerFolders) {
                     $createdFolder = $this->$createFolderFunction($parent, $folderName);

--- a/src/Command/FolderCreatorCommand.php
+++ b/src/Command/FolderCreatorCommand.php
@@ -51,10 +51,14 @@ class FolderCreatorCommand extends AbstractCommand
     {
         foreach ($folders as $folder) {
             if (is_string($folder)) {
-                if ($folder == 'A-Z') {
-                    $folder = ['(0-9)', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z'];
+                if ($folder == '<alphabetical>') {
+                    $folder = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z'];
                     $this->loopThroughFolders($folder, $parent, $createFolderFunction);
-                } else {
+                } else if ($folder == '<numerical>') {
+                    $folder = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
+                    $this->loopThroughFolders($folder, $parent, $createFolderFunction);
+                } 
+                else {
                     $this->$createFolderFunction($parent, $folder);
                 }
             } else if (is_array($folder)) {

--- a/src/Command/FolderCreatorCommand.php
+++ b/src/Command/FolderCreatorCommand.php
@@ -51,7 +51,7 @@ class FolderCreatorCommand extends AbstractCommand
     {
         foreach ($folders as $folder) {
             if (is_string($folder)) {
-                if ($folder == '[A-Z]') {
+                if ($folder == 'A-Z') {
                     $folder = ['(0-9)', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z'];
                     $this->loopThroughFolders($folder, $parent, $createFolderFunction);
                 } else {


### PR DESCRIPTION
Say you want a folder structure like this:
![image](https://user-images.githubusercontent.com/5866481/150124798-e1ff4cfe-cb2c-4044-86fd-f9308f25bde9.png)
To accomplish this, you'd need to specify a folder for each letter of the alphabet in folders.yml. This PR adds the ability to use a placeholder string "A-Z" as a shorthand for this behaviour.